### PR TITLE
shorthand argument names terminology, and ARC capture semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
       <span class='name'>array</span>.<span class='func'>sort</span> { (item1, item2) <span class='return'>in return</span> item1 &lt; item2 }
     </code>
 
-    <h2>As the last parameter, <strong>referred to by numbers</strong>:</h2>
+    <h2>As the last parameter, <strong>using shorthand argument names</strong>:</h2>
     <code>
       <span class='name'>array</span>.<span class='func'>sort</span> { <span class='return'>return</span> $0 &lt; $1 }
     </code>
@@ -195,6 +195,14 @@
     <h2>As the last parameter, <strong>as a reference to an existing function</strong>:</h2>
     <code>
       <span class='name'>array</span>.<span class='func'>sort</span>(&lt;)
+    </code>
+    <h2>As a function parameter <strong>with explicit capture semantics</strong>:</h2>
+    <code>
+      <span class='name'>array</span>.<span class='func'>sort</span>({ [unowned self] (item1: <span class='func'>Int</span>, item2: <span class='func'>Int</span>) -&gt; Bool <span class='return'>in return</span> item1 &lt; item2 })
+    </code>
+  <h2>As a function parameter <strong>with explicit capture semantics and inferred parameters / return type</strong>:</h2>
+    <code>
+      <span class='name'>array</span>.<span class='func'>sort</span>({ [unowned self] <span class='return'>in return</span> item1 &lt; item2 })
     </code>
   </div>
 


### PR DESCRIPTION
'Shorthand argument names' terminology to match the Swift Programming Language book, and added two examples of capture lists for ARC within closures.
