### PR TITLE
Renamed `func` to `funcName` in “As an argument to a function call:”

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
   <div>
     <h2>As an <strong>argument to a function call</strong>:</h2>
     <code>
-      <span class='name'>func</span>({(<span class='parameter-types'>ParameterTypes</span>) -&gt; (<span class='return'>ReturnType</span>) in statements})
+      <span class='name'>funcName</span>({(<span class='parameter-types'>ParameterTypes</span>) -&gt; (<span class='return'>ReturnType</span>) in statements})
     </code>
   </div>
 


### PR DESCRIPTION
Renamed function name in _“As an argument to a function call:”_ from `func` to `funcName`, because `func` is a keyword and its usage here as a placeholder identifier could trip up novice/intermediate Swift users (the intended audience of fuckingclosuresyntax.com, AFAIK).

`funcName` is also more consistent with the previous section — _“As a constant:”_ — which uses `closureName` as its placeholder identifier.
