### PR TITLE
Fixed example for “As a function parameter with explicit capture semantics and inferred parameters / return type:”

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
     </code>
   <h2>As a function parameter <strong>with explicit capture semantics and inferred parameters / return type</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span>({ [unowned self] <span class='return'>in return</span> item1 &lt; item2 })
+      <span class='name'>array</span>.<span class='func'>sort</span>({ [unowned self] <span class='return'>in return</span> $0 &lt; $1 })
     </code>
   </div>
 


### PR DESCRIPTION
Fixed the code example for the final section, _“As a function parameter with explicit capture semantics and inferred parameters / return type:”_.

Before it used `item1` & `item2` vars (args), which aren't declared in this example and cause _“Use of unresolved identifier '…'”_ compiler errors.  Replaced with `$0` & `$1` like the other examples with inferred parameters.
