### PR TITLE
Updated for Swift 3: `.sort(…)`→`.sorted(by: …)`

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,45 +164,45 @@
   <div>
     <h2>As a <strong>function parameter</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span>({ (item1: <span class='func'>Int</span>, item2: <span class='func'>Int</span>) -&gt; Bool <span class='return'>in return</span> item1 &lt; item2 })
+      <span class='name'>array</span>.<span class='func'>sorted</span>(<span class='func'>by:</span> { (item1: <span class='func'>Int</span>, item2: <span class='func'>Int</span>) -&gt; Bool <span class='return'>in return</span> item1 &lt; item2 })
     </code>
 
     <h2>As a <strong>function parameter with implied types</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span>({ (item1, item2) -&gt; Bool <span class='return'>in return</span> item1 &lt; item2 })
+      <span class='name'>array</span>.<span class='func'>sorted</span>(<span class='func'>by:</span> { (item1, item2) -&gt; Bool <span class='return'>in return</span> item1 &lt; item2 })
     </code>
 
     <h2>As a <strong>function parameter with implied return type</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span>({ (item1, item2) <span class='return'>in return</span> item1 &lt; item2 })
+      <span class='name'>array</span>.<span class='func'>sorted</span>(<span class='func'>by:</span> { (item1, item2) <span class='return'>in return</span> item1 &lt; item2 })
     </code>
 
     <h2>As the <strong>last function parameter</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span> { (item1, item2) <span class='return'>in return</span> item1 &lt; item2 }
+      <span class='name'>array</span>.<span class='func'>sorted</span> { (item1, item2) <span class='return'>in return</span> item1 &lt; item2 }
     </code>
 
     <h2>As the last parameter, <strong>using shorthand argument names</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span> { <span class='return'>return</span> $0 &lt; $1 }
+      <span class='name'>array</span>.<span class='func'>sorted</span> { <span class='return'>return</span> $0 &lt; $1 }
     </code>
 
     <h2>As the last parameter, <strong>with an implied return value</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span> { $0 &lt; $1 }
+      <span class='name'>array</span>.<span class='func'>sorted</span> { $0 &lt; $1 }
     </code>
 
     <h2>As the last parameter, <strong>as a reference to an existing function</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span>(&lt;)
+      <span class='name'>array</span>.<span class='func'>sorted</span>(<span class='func'>by:</span> &lt;)
     </code>
     <h2>As a function parameter <strong>with explicit capture semantics</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span>({ [unowned self] (item1: <span class='func'>Int</span>, item2: <span class='func'>Int</span>) -&gt; Bool <span class='return'>in return</span> item1 &lt; item2 })
+      <span class='name'>array</span>.<span class='func'>sorted</span>(<span class='func'>by:</span> { [unowned self] (item1: <span class='func'>Int</span>, item2: <span class='func'>Int</span>) -&gt; Bool <span class='return'>in return</span> item1 &lt; item2 })
     </code>
   <h2>As a function parameter <strong>with explicit capture semantics and inferred parameters / return type</strong>:</h2>
     <code>
-      <span class='name'>array</span>.<span class='func'>sort</span>({ [unowned self] <span class='return'>in return</span> $0 &lt; $1 })
+      <span class='name'>array</span>.<span class='func'>sorted</span>(<span class='func'>by:</span> { [unowned self] <span class='return'>in return</span> $0 &lt; $1 })
     </code>
   </div>
 


### PR DESCRIPTION
Updated the usage of `Array`'s `sort(…)` method to what it was renamed to in Swift 3— `.sorted(by: …)`.  This is matches what code tip Xcode would give a user if they tried to type in the code the preexisting way.  

Note: In Swift 3, `.sorted(by: …) -> [Element]` is the non-mutating form, like `sort(…) -> [Element]` was in Swift 2.  Swift 3 adds a mutating `.sort(by: …) -> Void` variant too.  _I think it continues to make sense to use the non-mutating forms here because their behavior is more explicit (especially important for newbies when used in a Playground)._  

Chose to syntax-highlight the `by:` as the same color as `sorted` _(using `<span class='func'>`)_ because Swift is designed for the argument labels to be read (mostly) as a sentence fragment, and the “true name” of a function (AKA its selector) is the initial name along with all its arg labels.  It looks nice on the website too— it reads cleanly as “sorted by” without looking too syntax-y.

Fixes Issue #14.