### PR TITLE
Added `target="_top"` to all links

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
   <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16">
   <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32">
   <meta name="apple-mobile-web-app-title" content="Closures" />
+  <base target="_top" />
   <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
In investigating issue #10 on my iPad, I found that the error _“Refused to display 'https://github.com/ZevEisenberg/fuckingclosuresyntax.com' in a frame because it set 'X-Frame-Options' to 'deny'.”_ was being output to the console, and then discovered that `goshdarnclosuresyntax.com` is a basic page with a sole `<iframe>` presenting `fuckingclosuresyntax.com`.  So what's happening here is that the link is trying to open up inside the frame instead of changing the URL of the whole browser page/window/tab/document (as links normally do).

Also, I discovered that while some links do work _(e.g. the “Zev Eisenberg” link)_, the URL remains `goshdarnclosuresyntax.com`.  So all the links need to be told to target the window instead of the frame.

* Added to the `<head>` a `<base target="_top" />` tag, which is the standard way of applying attributes to all links, and was pretty commonplace back when `<iframe>`s were a thing people used regularly.  
	‣ _My god has it been a long time since I've done anything with HTML `<iframe>`s.  This brings me straight back to 1998._  
	‣ Unfortunately, since this is a server setup issue I couldn't fully test that this works.  However, I did copy the source of `goshdarnclosuresyntax.com` into a local file, point the frame at `http://«my-machine».local:8080`, and then fire up my local repo and the local-`goshdarnclosuresyntax.com`-copy in a pair of `http-server`s and everything worked as expected in macOS Chrome, macOS Safari, iOS Safari, and iOS Chrome.

Resolves issue #10.